### PR TITLE
DIP-1: decrease advance incentives

### DIFF
--- a/protocol/contracts/Constants.sol
+++ b/protocol/contracts/Constants.sol
@@ -52,7 +52,7 @@ library Constants {
     uint256 private constant GOVERNANCE_EMERGENCY_DELAY = 6; // 6 epochs
 
     /* DAO */
-    uint256 private constant ADVANCE_INCENTIVE = 1e20; // 100 DSD
+    uint256 private constant ADVANCE_INCENTIVE = 25e18; // 25 DSD
     uint256 private constant DAO_EXIT_LOCKUP_EPOCHS = 36; // 36 epochs fluid
 
     /* Pool */


### PR DESCRIPTION
**Dynamic Improvement Proposal 1:** decrease advance incentives

**Considerations:**
During the bootstrapping period the price of DSD has so far been high above the 1$ price target as future supply expansions are priced in.
This opened the opportunity for some bot-runners to pay thousands of dollars to advance, earning 10s of thousands selling off the advance incentive immediately after into the LP pool.

**Proposed Solution:**
To respond to this in a timely manner, a community member suggested we opt for the most simple solution and lower the advance incentive to **25 DSD**.
This decrease should drastically lower the impact that these bots have on the gas prices and the LP pool, while keeping incentives high enough for people to call advance.